### PR TITLE
Add rotation to bomb counter label.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,9 @@ sysinfo.txt
 # Builds
 *.apk
 *.unitypackage
+launch.json
+VSCode.meta
+Assets/VSCode/Plugins.meta
+Assets/VSCode/Plugins/Editor.meta
+Assets/VSCode/Plugins/Editor/VSCode.cs
+Assets/VSCode/Plugins/Editor/VSCode.cs.meta

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -243,6 +243,7 @@ Canvas:
   m_ReceivesEvents: 1
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0

--- a/Assets/Scripts/ExplosionManager.cs
+++ b/Assets/Scripts/ExplosionManager.cs
@@ -11,12 +11,12 @@ public class ExplosionManager : MonoBehaviour {
 
     public GameManager gameManager;
 
-    public void PutBomb(Bomb bomb, Vector2 position)
+    public void PutBomb(GameObject player, Bomb bomb, Vector2 position)
     {
         GameCell cell = gameManager.GetBoard().GetGameCell(position);
         if (cell != null && cell.block == null && cell.bomb == null)
         {
-            doPutBomb(bomb, cell);
+            doPutBomb(player, bomb, cell);
         } else
         {
             Debug.Log(DateTime.Now + " You can't place a bomb here!");
@@ -24,12 +24,13 @@ public class ExplosionManager : MonoBehaviour {
         }
     }
 
-    private void doPutBomb(Bomb bombPrefab, GameCell gameCell)
+    private void doPutBomb(GameObject player, Bomb bombPrefab, GameCell gameCell)
     {
         Vector3 bombPosition = gameManager.GetPositionConverter().ConvertBoardPositionToScene(gameCell.GetCoordinates(), true);
         bombPosition.y = bombPrefab.transform.localScale.y / 1.5f;
 
         Bomb bomb = Instantiate(bombPrefab, bombPosition, Quaternion.identity) as Bomb;
+        bomb.player = player;
         gameCell.bomb = bomb;
 
         StartCoroutine(handleBombPlaced(bomb, gameCell));

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -41,6 +41,8 @@ public class GameManager : MonoBehaviour {
     private Maze mazeInstance;
 
     private Board board;
+    
+    private Player player;
 
     private PositionConverter positionConverter;
 
@@ -58,7 +60,7 @@ public class GameManager : MonoBehaviour {
         if (Input.GetKeyDown("f")) {
             Vector3 sceneBombPosition = board.GetPlayers()[0].transform.position + board.GetPlayers()[0].transform.forward;
             Vector2 boardBombPosition = positionConverter.ConvertScenePositionToBoard(sceneBombPosition);
-            explosionManager.PutBomb(bombPrefab, boardBombPosition);
+            explosionManager.PutBomb(player.gameObject, bombPrefab, boardBombPosition);
         }
     }
 
@@ -72,7 +74,7 @@ public class GameManager : MonoBehaviour {
         float startZ = startPositionZ.Equals(StartPosition.MIN) ? 1 : mazeLength - 1;
         board = mazeInstance.Generate(mazeWidth, mazeLength, cellSize, cubeHeight, wallHeight, startX, startZ, positionConverter);
 
-        Player player = Instantiate(playerPrefab);
+        player = Instantiate(playerPrefab);
         player.transform.localPosition = new Vector3(startX, 0.5f, startZ);
         if (startPositionZ.Equals(StartPosition.MAX))
         {

--- a/Assets/Scripts/Model/Bomb.cs
+++ b/Assets/Scripts/Model/Bomb.cs
@@ -18,6 +18,8 @@ namespace Assets.Scripts.Model
         private TextMesh textMesh;
 
         private bool detonated = false;
+        
+        public GameObject player {get; set;}
 
         public override void OnExplode()
         {
@@ -28,6 +30,12 @@ namespace Assets.Scripts.Model
         void Awake()
         {
             textMesh = GetComponentInChildren<TextMesh>();
+        }
+        
+        void Update()
+        {
+            this.textMesh.transform.LookAt(player.gameObject.transform);
+            this.textMesh.transform.Rotate(new Vector3(0f, 180f, 0f));
         }
 
         public void SetCountValue(int value)

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 5.3.3f1
+m_EditorVersion: 5.3.4f1
 m_StandardAssetsVersion: 0


### PR DESCRIPTION
The label will face current player's direction. This way it's always visible and correctly displayed.
